### PR TITLE
Stop filtering blogs by the content column

### DIFF
--- a/api-version/app/controllers/api/v1/blogs_controller.rb
+++ b/api-version/app/controllers/api/v1/blogs_controller.rb
@@ -4,9 +4,9 @@ class Api::V1::BlogsController < ApplicationController
   # GET /api/v1/blogs
   def index
     blogs = Blog.all
-    blogs = blogs.search(params[:q]) if params[:q].present?
+    blogs = blogs.filter_by_title(params[:title]) if params[:title].present?
     blogs = blogs.filter_by_status(params[:status]) if params[:status].present?
-    
+
     render json: blogs
   end
 

--- a/api-version/app/controllers/api/v1/blogs_controller.rb
+++ b/api-version/app/controllers/api/v1/blogs_controller.rb
@@ -3,9 +3,24 @@ class Api::V1::BlogsController < ApplicationController
 
   # GET /api/v1/blogs
   def index
+    # TODO: paginationを実装する
+    # TODO: class methodを利用してフィルタリングする
+    # blogs = Blog.filter_by_title(params[:title])
+    #             .filter_by_status(params[:status])
     blogs = Blog.all
-    blogs = blogs.filter_by_title(params[:title]) if params[:title].present?
-    blogs = blogs.filter_by_status(params[:status]) if params[:status].present?
+    if params[:title].present?
+      sanitized_title = sanitize_sql_for_conditions(["title LIKE ?", "%#{params[:title]}%"])
+      blogs = blogs.where(sanitized_title)
+    end
+
+    if params[:status].present?
+      case params[:status]
+      when 'published'
+        blogs = blogs.published
+      when 'unpublished'
+        blogs = blogs.unpublished
+      end
+    end
 
     render json: blogs
   end

--- a/api-version/app/models/blog.rb
+++ b/api-version/app/models/blog.rb
@@ -5,13 +5,19 @@ class Blog < ApplicationRecord
   scope :published, -> { where(published: true) }
   scope :unpublished, -> { where(published: false) }
 
+  # @param [String] title
+  # @return [Blog::ActiveRecord_Relation]
   def self.filter_by_title(title)
-    return all if title.blank?
-    sanitized_title = sanitize_sql_for_conditions(["title LIKE ?", "%#{title}%"])
+    # メソッドチェーンを継続するためにcurrent_scopeを返す
+    # reference: https://github.com/rails/rails/blob/7b96382519b8bdd0156ab63c849728e38039293b/activerecord/lib/active_record/scoping.rb#L25-L27
+    return current_scope if title.blank?
 
+    sanitized_title = sanitize_sql_for_conditions(["title LIKE ?", "%#{title}%"])
     where(sanitized_title)
   end
 
+  # @param [String] status
+  # @return [Blog::ActiveRecord_Relation]
   def self.filter_by_status(status)
     case status
     when 'published'
@@ -19,7 +25,9 @@ class Blog < ApplicationRecord
     when 'unpublished'
       unpublished
     else
-      all
+      # メソッドチェーンを継続するためにcurrent_scopeを返す
+      # reference: https://github.com/rails/rails/blob/7b96382519b8bdd0156ab63c849728e38039293b/activerecord/lib/active_record/scoping.rb#L25-L27
+      current_scope
     end
   end
 end

--- a/api-version/app/models/blog.rb
+++ b/api-version/app/models/blog.rb
@@ -5,10 +5,11 @@ class Blog < ApplicationRecord
   scope :published, -> { where(published: true) }
   scope :unpublished, -> { where(published: false) }
 
-  def self.search(query)
-    return all if query.blank?
+  def self.filter_by_title(title)
+    return all if title.blank?
+    sanitized_title = sanitize_sql_for_conditions(["title LIKE ?", "%#{title}%"])
 
-    where("title LIKE :query OR content LIKE :query", query: "%#{query}%")
+    where(sanitized_title)
   end
 
   def self.filter_by_status(status)


### PR DESCRIPTION
## Overview
- Stop filtering blogs by the content column.
- Inline logic in `BlogsController#index` instead of using a model method.
  - By the way, I intentionally wrote code that is harder to test because it's for a blog post.

